### PR TITLE
add new aerial imagery layer from PDOK/beeldmateriaal.nl

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -24,6 +24,13 @@ function createMap(config) {
 		title: 'Base Layers',
 		layers: [
 			new ol.layer.Tile({title: "Blank", type: 'base'}),
+			new ol.layer.Tile({
+				title: "Aerial Imagery", type: 'base',
+				source: new ol.source.OSM({
+					attributions: 'Kadaster / <a href="http://www.beeldmateriaal.nl/">Beeldmateriaal.nl</a>, CC BY 4.0',
+					url: 'https://geodata.nationaalgeoregister.nl/luchtfoto/wmts?FORMAT=image/jpeg&SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=2016_ortho25&STYLE=&FORMAT=image/jpeg&tileMatrixSet=OGC:1.0:GoogleMapsCompatible&tileMatrix={z}&tileRow={y}&tileCol={x}',
+				})
+			}),
 			new ol.layer.Tile({title: "OSM", type: 'base', source: new ol.source.OSM()}),
 		]
 	});


### PR DESCRIPTION
This adds a new base layer with high resolution (25 cm) aerial imagery from 2016 provided by PDOK.

Please note: Before merging/deploying this, please let a native speaker of dutch check that their license and TOS really allows the usage on the SHA website. Google Translate says it does, but...
Relevant URLs for that would be: https://www.pdok.nl/nl/actueel/nieuws/artikel/10feb17-nieuw-hogere-resolutie-luchtfoto-als-open-data-bij-pdok http://www.nationaalgeoregister.nl/geonetwork/srv/dut/catalog.search#/metadata/c82a783a-9a58-4761-a809-b4c5d90dcd35 https://www.pdok.nl/nl/service/wmts-luchtfoto-beeldmateriaal-pdok-25-cm-rgb